### PR TITLE
Update vmware_inventory.py

### DIFF
--- a/inventory_plugins/python3/vmware_inventory.py
+++ b/inventory_plugins/python3/vmware_inventory.py
@@ -377,7 +377,7 @@ class VMWareInventory(object):
         self.debugl('lower keys is %s' % self.lowerkeys)
         self.skip_keys = list(config.get('vmware', 'skip_keys').split(','))
         self.debugl('skip keys is %s' % self.skip_keys)
-        temp_host_filters = list(config.get('vmware', 'host_filters').split('}},'))
+        temp_host_filters = list(os.environ.get('VMWARE_HOST_FILTERS', config.get('vmware', 'host_filters')).split('}},'))
         for host_filter in temp_host_filters:
             host_filter = host_filter.rstrip()
             if host_filter != "":


### PR DESCRIPTION
#1 
Added the ability to pull the host_filters from the environment variables, which is necessary for using host_filters through Ansible Tower/ AWX web GUI.

In the AWX/Tower GUI, copy/paste the script into a Custom Script field, and add the following in the custom script's ENVIRONMENT VARIABLES field with syntax as shown below for host filters:
```
VMWARE_INCLUDE_TAGS: True
VMWARE_HOST_FILTERS: '{{ runtime.powerstate == "poweredOn" }}, {{ "AnsibleTowerManaged" in tags.managedBy }}, {{ "<partial match>" in name }}, {{ name == "<exactmatch>" }}'
 ```